### PR TITLE
Dockerhub pull rate limit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMAGE=ubuntu:20.04
+ARG BASE_IMAGE=public.ecr.aws/lts/ubuntu:20.04
 FROM ${BASE_IMAGE} AS dev-base
 RUN apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile.dynamo
+++ b/docker/Dockerfile.dynamo
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMAGE=ubuntu:20.04
+ARG BASE_IMAGE=public.ecr.aws/lts/ubuntu:20.04
 FROM ${BASE_IMAGE} AS dev-base
 RUN apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile.ipex
+++ b/docker/Dockerfile.ipex
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMAGE=ubuntu:20.04
+ARG BASE_IMAGE=public.ecr.aws/lts/ubuntu:20.04
 FROM ${BASE_IMAGE} AS dev-base
 RUN apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
This pr use **[Amazon ECR Public Gallery](https://gallery.ecr.aws/)** for public docker images to bypass docker hub pull rate limit for  anonymous user. Before, error message bellow got during building [ci job](https://inteltf-jenk.sh.intel.com/job/inductor_images/219/console).

```bash
+ DOCKER_BUILDKIT=1 docker build --no-cache --build-arg http_proxy=http://proxy-dmz.intel.com:911/ --build-arg https_proxy=http://proxy-dmz.intel.com:912/ --build-arg PT_REPO=https://github.com/pytorch/pytorch.git --build-arg PT_BRANCH=nightly --build-arg PT_COMMIT=nightly --build-arg TORCH_VISION_BRANCH=nightly --build-arg TORCH_VISION_COMMIT=nightly --build-arg TORCH_DATA_BRANCH=nightly --build-arg TORCH_DATA_COMMIT=nightly --build-arg TORCH_TEXT_BRANCH=nightly --build-arg TORCH_TEXT_COMMIT=nightly --build-arg TORCH_AUDIO_BRANCH=nightly --build-arg TORCH_AUDIO_COMMIT=nightly --build-arg TORCH_BENCH_BRANCH=main --build-arg TORCH_BENCH_COMMIT=main --build-arg BENCH_COMMIT=nightly -t ccr-registry.caas.intel.com/pytorch/pt_inductor:nightly -f Dockerfile --target image .
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.1s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 4.63kB done
#2 DONE 0.1s

#3 resolve image config for docker.io/docker/dockerfile:1
#3 DONE 0.7s

#4 docker-image://docker.io/docker/dockerfile:1@sha256:39b85bbfa7536a5feceb7372a0817649ecb2724562a38360f4d6a7782a409b14
#4 resolve docker.io/docker/dockerfile:1@sha256:39b85bbfa7536a5feceb7372a0817649ecb2724562a38360f4d6a7782a409b14 done
#4 sha256:966d40f9ba8366e74c2fa353fc0bc7bbc167d2a0f3ad2420db8b9e633049462d 482B / 482B done
#4 sha256:dbdd11720762ad504260c66161c964e59eba06b95a7aa64a68634b598a830a91 2.90kB / 2.90kB done
#4 sha256:a47ff7046597eea0123ea02817165350e3680f75000dc5d69c9a310258e1bedd 0B / 11.55MB 0.1s
#4 sha256:39b85bbfa7536a5feceb7372a0817649ecb2724562a38360f4d6a7782a409b14 8.40kB / 8.40kB done
#4 sha256:a47ff7046597eea0123ea02817165350e3680f75000dc5d69c9a310258e1bedd 8.39MB / 11.55MB 0.2s
#4 sha256:a47ff7046597eea0123ea02817165350e3680f75000dc5d69c9a310258e1bedd 11.55MB / 11.55MB 0.3s done
#4 extracting sha256:a47ff7046597eea0123ea02817165350e3680f75000dc5d69c9a310258e1bedd
#4 extracting sha256:a47ff7046597eea0123ea02817165350e3680f75000dc5d69c9a310258e1bedd 0.2s done
#4 DONE 0.5s

#5 [internal] load metadata for docker.io/library/ubuntu:20.04
#5 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/ubuntu/manifests/sha256:9fa30fcef427e5e88c76bc41ad37b7cc573e1d79cecb23035e413c4be6e476ab: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
------
 > [internal] load metadata for docker.io/library/ubuntu:20.04:
------
Dockerfile:3
--------------------
   1 |     # syntax=docker/dockerfile:1
   2 |     ARG BASE_IMAGE=ubuntu:20.04
   3 | >>> FROM ${BASE_IMAGE} AS dev-base
   4 |     RUN apt-get update && \
   5 |             DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
--------------------
ERROR: failed to solve: ubuntu:20.04: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/ubuntu/manifests/sha256:9fa30fcef427e5e88c76bc41ad37b7cc573e1d79cecb23035e413c4be6e476ab: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
[Pipeline] }
ERROR: script returned exit code 1

```