### PR TITLE
add wget in dockfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
         libxext6 \
         numactl \
         pybind11-dev \
+        wget \
         vim \
     && rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/update-ccache-symlinks

--- a/docker/Dockerfile.dynamo
+++ b/docker/Dockerfile.dynamo
@@ -17,6 +17,7 @@ RUN apt-get update && \
         libxext6 \
         numactl \
         pybind11-dev \
+        wget \
         vim \
     && rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/update-ccache-symlinks

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -18,6 +18,7 @@ RUN apt-get update && \
         libxext6 \
         numactl \
         pybind11-dev \
+        wget \
         vim \
     && rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/update-ccache-symlinks

--- a/docker/Dockerfile.ipex
+++ b/docker/Dockerfile.ipex
@@ -17,6 +17,7 @@ RUN apt-get update && \
         libxext6 \
         numactl \
         pybind11-dev \
+        wget \
         vim \
     && rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/update-ccache-symlinks


### PR DESCRIPTION
`wget` used but not installed https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/sam/install.py#L9
```
cd benchmarks && python install.py sam

#17 774.0 running setup for /workspace/benchmark/torchbenchmark/models/sam...FAIL
#17 777.0 Error for /workspace/benchmark/torchbenchmark/models/sam:
#17 777.0 ---------------------------------------------------------------------------
#17 777.0 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
#17 777.0 Traceback (most recent call last):
#17 777.0   File "install.py", line 22, in <module>
#17 777.0     download_checkpoint()
#17 777.0   File "install.py", line 9, in download_checkpoint
#17 777.0     subprocess.check_call(['wget', '-P', '.data', 'https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth'])
#17 777.0   File "/opt/conda/lib/python3.8/subprocess.py", line 359, in check_call
#17 777.0     retcode = call(*popenargs, **kwargs)
#17 777.0   File "/opt/conda/lib/python3.8/subprocess.py", line 340, in call
#17 777.0     with Popen(*popenargs, **kwargs) as p:
#17 777.0   File "/opt/conda/lib/python3.8/subprocess.py", line 858, in __init__
#17 777.0     self._execute_child(args, executable, preexec_fn, close_fds,
#17 777.0   File "/opt/conda/lib/python3.8/subprocess.py", line 1704, in _execute_child
#17 777.0     raise child_exception_type(errno_num, err_msg, err_filename)
#17 777.0 FileNotFoundError: [Errno 2] No such file or directory: 'wget'

```