### PR TITLE
fix cpp generate report issue due to machine down

### DIFF
--- a/groovy/inductor_aws_benchmark.groovy
+++ b/groovy/inductor_aws_benchmark.groovy
@@ -475,6 +475,10 @@ node(NODE_LABEL){
                     echo restart instance now...
                     $aws ec2 stop-instances --instance-ids ${ins_id} --profile pytorch && sleep 2m && $aws ec2 start-instances --instance-ids ${ins_id} --profile pytorch && sleep 2m && current_ip=$($aws ec2 describe-instances --instance-ids ${ins_id} --profile pytorch --query 'Reservations[*].Instances[*].PublicDnsName' --output text) && echo update_ip $current_ip || echo $current_ip
                     ssh -o StrictHostKeyChecking=no ubuntu@${current_ip} "pwd"
+                    if [ -d ${WORKSPACE}/${_target} ]; then
+                        rm -rf ${WORKSPACE}/${_target}
+                    fi
+                    mkdir -p ${WORKSPACE}/${_target}
                     scp -r ubuntu@${current_ip}:/home/ubuntu/docker/inductor_log ${WORKSPACE}/${_target}
                     break
                 fi


### PR DESCRIPTION
**Reason:**
1. The machine is down and rebooted before generating the report. So, the folder `${WORKSPACE}/${_target}` is not existed.

**Error:**
```shell
  File "/home2/yudongsi/anaconda3/lib/python3.9/site-packages/pandas/io/common.py", line 571, in check_parent_directory
    raise OSError(rf"Cannot save file into a non-existent directory: '{parent}'")
OSError: Cannot save file into a non-existent directory: '2023_11_21/inductor_log'
```