### PR TITLE
fix issue about first unique failure was ignored

### DIFF
--- a/scripts/modelbench/report.py
+++ b/scripts/modelbench/report.py
@@ -352,7 +352,6 @@ def update_failures(excel,target_thread,refer_thread):
         refer_thread_failures = get_failures(refer_thread)
         compare = datacompy.Compare(target_thread_failures, refer_thread_failures, join_columns='name')
         failure_regression = compare.df1_unq_rows.copy()
-        failure_regression.loc[0] = list(failure_regression.shape[1]*'*')
         new_failures = pd.concat([new_failures,failure_regression])
 
     sf = StyleFrame({'suite': list(target_thread_failures['suite']),


### PR DESCRIPTION
# Issue:
The first unique issue compared between 2 report will be ignored and turn into `*`. Not sure how this line work.

![image](https://github.com/chuanqi129/inductor-tools/assets/84730719/2b45acf5-032c-4992-8e40-6c65ca80ab03)
