### PR TITLE
Fix torchbench install crash issue caused by torchdata

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,7 +112,7 @@ RUN git clone -b ${TORCH_BENCH_BRANCH} https://github.com/pytorch/benchmark.git 
 ARG BENCH_COMMIT=${PT_COMMIT}
 WORKDIR /workspace/pytorch
 RUN git checkout ${BENCH_COMMIT} benchmarks && \
-    python -c "import torch, torchvision, torchtext"
+    python -c "import torch, torchvision, torchaudio"
 
 # Clean for final image
 FROM dev-base AS image


### PR DESCRIPTION
The latest torchbench doesn't depend on torchtext, but still keep torchtext/data build and install part to compatible with old torchbench version. 
cc: @zxd1997066 @WeizhuoZhang-intel @mengfei25 