### PR TITLE
Add target folder when copyArtifacts for refer build

### DIFF
--- a/groovy/inductor_aws_benchmark.groovy
+++ b/groovy/inductor_aws_benchmark.groovy
@@ -529,11 +529,12 @@ node(NODE_LABEL){
                 copyArtifacts(
                     projectName: currentBuild.projectName,
                     selector: specific("${refer_build}"),
-                    fingerprintArtifacts: true
+                    fingerprintArtifacts: true,
+                    target: "refer",
                 )           
                 sh '''
                 #!/usr/bin/env bash
-                cd ${WORKSPACE} && mkdir -p refer && cp -r inductor_log refer && rm -rf inductor_log
+                cd ${WORKSPACE}
                 if [ ${_dash_board} == "true" ]; then
                     cp scripts/modelbench/report.py ${WORKSPACE} && python report.py -r refer -t ${_target} -m ${_THREADS} --precision ${_precision} --gh_token ${_gh_token} --dashboard ${_dashboard_title} --url ${BUILD_URL} --image_tag ${_target}_aws --suite ${_suite} --infer_or_train ${_infer_or_train} --shape ${_shape} --wrapper ${_WRAPPER} --torch_repo ${_TORCH_REPO} --torch_branch ${_TORCH_BRANCH} && rm -rf refer
                 else


### PR DESCRIPTION
## issue
I found that currently when using copyArtifacts for refer build will copy all the files into `${WORKSPACE`} folder. But there is one case that when there is no new files generated by target_build, but it downloaded from refer_build. The refer_build files will be upload to jenkins.
![image](https://github.com/chuanqi129/inductor-tools/assets/84730719/49b6150a-6d64-4b43-9387-a469b909c5ff)


## Solution
use `target` argument in `copyArtifacts` which force to download the  artifacts of refer build into a specific folder.