### PR TITLE
add StrictHostKeyChecking=no for collecting finish.txt

### DIFF
--- a/groovy/inductor_aws_benchmark.groovy
+++ b/groovy/inductor_aws_benchmark.groovy
@@ -476,7 +476,7 @@ node(NODE_LABEL){
         for t in {1..100}
         do
             current_ip=`$aws ec2 describe-instances --instance-ids ${ins_id} --profile pytorch --query 'Reservations[*].Instances[*].PublicDnsName' --output text`
-            timeout 2m ssh ubuntu@${current_ip} "test -f /home/ubuntu/docker/finished_${_precision}_${_test_mode}_${_shape}.txt"
+            timeout 2m ssh -o StrictHostKeyChecking=no ubuntu@${current_ip} "test -f /home/ubuntu/docker/finished_${_precision}_${_test_mode}_${_shape}.txt"
             if [ $? -eq 0 ]; then
                 if [ -d ${WORKSPACE}/${_target} ]; then
                     rm -rf ${WORKSPACE}/${_target}


### PR DESCRIPTION
## Issue:
Reboot machine causes new IP allocated which requires fingerprint when first connection.
This issue will cause connection timeout on Jenkins job.

![image](https://github.com/chuanqi129/inductor-tools/assets/84730719/cd60a50c-9c92-49ee-92f9-1219976eab93)


![image](https://github.com/chuanqi129/inductor-tools/assets/84730719/6875398c-f779-4f53-aa9e-1f5c5c54fb61)


