### PR TITLE
add Transformers version in pined torch repo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,6 +81,7 @@ ARG TORCH_TEXT_BRANCH=main
 ARG TORCH_TEXT_COMMIT=default
 ARG TORCH_AUDIO_BRANCH=main
 ARG TORCH_AUDIO_COMMIT=default
+ARG TRANSFORMERS_VERSION=main
 RUN git clone -b ${TORCH_VISION_BRANCH} https://github.com/pytorch/vision.git && \
     cd vision && if [ "${TORCH_VISION_COMMIT}" = "default" ]; then git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt`; else git checkout ${TORCH_VISION_COMMIT}; fi && \
     python setup.py bdist_wheel && \
@@ -97,6 +98,10 @@ RUN git clone -b ${TORCH_VISION_BRANCH} https://github.com/pytorch/vision.git &&
     cd audio && if [ "${TORCH_AUDIO_COMMIT}" = "default" ]; then git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt`; else git checkout ${TORCH_AUDIO_COMMIT}; fi && git submodule sync && git submodule update --init --recursive && \
     # Workaround for https://github.com/pytorch/audio/issues/2784
     sed -i "3 i link_directories(/opt/conda/lib)" CMakeLists.txt && \
+    python setup.py bdist_wheel && \
+    pip install dist/*.whl && cd .. && \
+    git clone -b ${TRANSFORMERS_VERSION} https://github.com/huggingface/transformers.git && \
+    cd transformers && git checkout `cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && git submodule sync && git submodule update --init --recursive && \
     python setup.py bdist_wheel && \
     pip install dist/*.whl && cd ..
 ARG TORCH_BENCH_BRANCH=main

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,6 @@ ARG TORCH_TEXT_BRANCH=main
 ARG TORCH_TEXT_COMMIT=default
 ARG TORCH_AUDIO_BRANCH=main
 ARG TORCH_AUDIO_COMMIT=default
-ARG TRANSFORMERS_VERSION=main
 RUN git clone -b ${TORCH_VISION_BRANCH} https://github.com/pytorch/vision.git && \
     cd vision && if [ "${TORCH_VISION_COMMIT}" = "default" ]; then git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt`; else git checkout ${TORCH_VISION_COMMIT}; fi && \
     python setup.py bdist_wheel && \
@@ -99,19 +98,20 @@ RUN git clone -b ${TORCH_VISION_BRANCH} https://github.com/pytorch/vision.git &&
     # Workaround for https://github.com/pytorch/audio/issues/2784
     sed -i "3 i link_directories(/opt/conda/lib)" CMakeLists.txt && \
     python setup.py bdist_wheel && \
-    pip install dist/*.whl && cd .. && \
-    git clone -b ${TRANSFORMERS_VERSION} https://github.com/huggingface/transformers.git && \
-    cd transformers && git checkout `cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && git submodule sync && git submodule update --init --recursive && \
-    python setup.py bdist_wheel && \
     pip install dist/*.whl && cd ..
 ARG TORCH_BENCH_BRANCH=main
 ARG TORCH_BENCH_COMMIT=default
+ARG TRANSFORMERS_VERSION=main
 ARG HF_HUB_TOKEN=hf_xxx
 ENV HUGGING_FACE_HUB_TOKEN ${HF_HUB_TOKEN}
 RUN git clone -b ${TORCH_BENCH_BRANCH} https://github.com/pytorch/benchmark.git && \
     cd benchmark && if [ "${TORCH_BENCH_COMMIT}" = "default" ]; then git checkout `cat /workspace/pytorch/.github/ci_commit_pins/torchbench.txt`; else git checkout ${TORCH_BENCH_COMMIT}; fi && pip install --no-deps -r requirements.txt && \
     pip install --no-cache Jinja2==3.1.2 markupsafe==2.0.1 beartype==0.15.0 mpmath==1.3.0 && \
-    python install.py --continue_on_fail && \
+    python install.py --continue_on_fail && cd .. && \
+    git clone -b ${TRANSFORMERS_VERSION} https://github.com/huggingface/transformers.git && \
+    cd transformers && git checkout `cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && git submodule sync && git submodule update --init --recursive && \
+    python setup.py bdist_wheel && \
+    pip install dist/*.whl && cd .. && \
     # Need update numpy version to avoid some models crash
     pip install --upgrade numpy
 ARG BENCH_COMMIT=${PT_COMMIT}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,17 +101,25 @@ RUN git clone -b ${TORCH_VISION_BRANCH} https://github.com/pytorch/vision.git &&
     pip install dist/*.whl && cd ..
 ARG TORCH_BENCH_BRANCH=main
 ARG TORCH_BENCH_COMMIT=default
-ARG TRANSFORMERS_VERSION=main
+ARG TRANSFORMERS_VERSION=default
 ARG HF_HUB_TOKEN=hf_xxx
 ENV HUGGING_FACE_HUB_TOKEN ${HF_HUB_TOKEN}
 RUN git clone -b ${TORCH_BENCH_BRANCH} https://github.com/pytorch/benchmark.git && \
     cd benchmark && if [ "${TORCH_BENCH_COMMIT}" = "default" ]; then git checkout `cat /workspace/pytorch/.github/ci_commit_pins/torchbench.txt`; else git checkout ${TORCH_BENCH_COMMIT}; fi && pip install --no-deps -r requirements.txt && \
     pip install --no-cache Jinja2==3.1.2 markupsafe==2.0.1 beartype==0.15.0 mpmath==1.3.0 && \
     python install.py --continue_on_fail && cd .. && \
-    git clone -b ${TRANSFORMERS_VERSION} https://github.com/huggingface/transformers.git && \
-    cd transformers && git checkout `cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && git submodule sync && git submodule update --init --recursive && \
-    python setup.py bdist_wheel && \
-    pip install dist/*.whl && cd .. && \
+    echo ${TRANSFORMERS_VERSION} && if [ "${TRANSFORMERS_VERSION}" = "default" ]; then \
+        git clone https://github.com/huggingface/transformers.git; \
+        cd transformers; \
+        git submodule sync; \
+        git submodule update --init --recursive; \
+        git checkout `cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt`; \
+        python setup.py bdist_wheel;  \
+        pip install dist/*.whl; \
+        cd ../; \
+    else \
+        pip install transformers==${TRANSFORMERS_VERSION}; \
+    fi && \
     # Need update numpy version to avoid some models crash
     pip install --upgrade numpy
 ARG BENCH_COMMIT=${PT_COMMIT}

--- a/scripts/modelbench/bisect_run_test.sh
+++ b/scripts/modelbench/bisect_run_test.sh
@@ -25,6 +25,7 @@ prepare_test() {
     rm -rf data && git clone -b main https://github.com/pytorch/data.git && cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     rm -rf text && git clone -b main https://github.com/pytorch/text.git && cd text && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/text.txt` && pip uninstall torchtext -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     rm -rf audio && git clone -b main https://github.com/pytorch/audio.git && cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
+    rm -rf transformers && git clone -b main https://github.com/huggingface/transformers.git && cd transformers && git checkout `cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && pip uninstall transformers -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd benchmark && git checkout main && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/torchbench.txt` && cd /workspace/pytorch
 }
 

--- a/scripts/modelbench/bisect_search.sh
+++ b/scripts/modelbench/bisect_search.sh
@@ -42,6 +42,7 @@ if [ "$SCENARIO" == "performance" ] && ([ "$KIND" == "drop" ] || [ "$KIND" == "i
     rm -rf data && git clone -b main https://github.com/pytorch/data.git && cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     rm -rf text && git clone -b main https://github.com/pytorch/text.git && cd text && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/text.txt` && pip uninstall torchtext -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     rm -rf audio && git clone -b main https://github.com/pytorch/audio.git && cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
+    rm -rf transformers && git clone -b main https://github.com/huggingface/transformers.git && cd transformers && git checkout `cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && pip uninstall transformers -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd benchmark && git checkout main && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/torchbench.txt` && cd /workspace/pytorch
     detected_value=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $PRECISION $CHANNELS $SHAPE $WRAPPER $BS $FREEZE $BACKEND | tail -n 1 | awk -F, '{print $5}')
     current_perf=$(echo $detected_value | awk '{ printf "%.5f", $1/1000 }')

--- a/scripts/modelbench/inductor_test.sh
+++ b/scripts/modelbench/inductor_test.sh
@@ -24,8 +24,6 @@ EXTRA=${11}
 mkdir -p $LOG_DIR
 
 export HUGGING_FACE_HUB_TOKEN=${HF_TOKEN}
-# https://github.com/pytorch/pytorch/issues/107200
-pip uninstall transformers -y && pip install transformers==4.30.2
 # fix issue: AttributeError: module 'importlib.resources' has no attribute 'files'
 pip uninstall networkx -y && pip install networkx
 


### PR DESCRIPTION
Test Case:

- [x] [Guilty commmit search for checking Dockerfile correctness](https://inteltf-jenk.sh.intel.com/user/weizhuo/my-views/view/weizhuoz_view/job/inductor_aws_guilty_commit_search_zwz/27/)
log: [torchbench-hf_BigBird-inference-float32-dynamic-cpp-multiple-accuracy-crash_guilty_commit.log.txt](https://github.com/chuanqi129/inductor-tools/files/14691572/torchbench-hf_BigBird-inference-float32-dynamic-cpp-multiple-accuracy-crash_guilty_commit.log.txt)

- [x] [Full scope of torch dynamo test. ](https://inteltf-jenk.sh.intel.com/user/weizhuo/my-views/view/weizhuoz_view/job/inductor_aws_regular_dashboard_release_zwz/4/)
llava model failure has been fixed by transformers update.

| suite | name | accuracy | perf | reason(reference only)
-- | -- | -- | -- | --
torchbench | torchrec_dlrm | X | X | torchrec_dlrm, AttributeError: '_OpNamespace' 'fbgemm' object has no attribute 'jagged_2d_to_dense'
torchbench | DALLE2_pytorch | X | X | DALLE2_pytorch, NotImplementedError: DALL-E 2 Not Supported on CPU
torchbench | llava | X | √ | llava, RuntimeError: Quantize only works on Float Tensor got Double
torchbench | moco | X | X | moco, NotImplementedError: DistributedDataParallel/allgather requires cuda
torchbench | simple_gpt | X | X | simple_gpt, NotImplementedError: Model requires CUDA
torchbench | timm_efficientdet | X | X | timm_efficientdet, NotImplementedError: The original model code forces the use of CUDA.
torchbench | pyhpc_equation_of_state | √ | NaN | pyhpc_equation_of_state, AssertionError: ((41616 26) (1082016 ))
