### PR TITLE
Fix job compare lastSuccessful job bug

### DIFF
--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -216,6 +216,7 @@ node(NODE_LABEL){
             env._suite = params.get('suite')
             env._precision = params.get('precision')
             env.backend = params.get('backend')
+            env.thread = params.get('THREADS')
 
             def ref_params = getUpstreamParameters(_refer_job, _refer_sc)
             env.ref_backend = ref_params.get('backend')
@@ -236,9 +237,9 @@ node(NODE_LABEL){
             pip install scipy datacompy PyGithub styleframe pandas bs4 requests
             cp scripts/modelbench/report.py ${WORKSPACE}
             if [ ${_cppwp_gm} == 'True' ];then
-                python report.py -r ${_refer_job}_${_refer_sc} -t ${_target_job}_${_target_sc} -m all --md_off --url ${BUILD_URL} --precision ${_precision} --cppwrapper_gm --mt_interval_start ${_mt_start} --mt_interval_end ${_mt_end} --st_interval_start ${_st_start} --st_interval_end ${_st_end} --suite ${_suite} --infer_or_train ${_infer_or_train} --shape ${shape} --wrapper ${wrapper} --torch_repo ${torch_repo} --torch_branch ${torch_branch}  --backend ${backend} --threshold ${threshold} --ref_backend ${ref_backend} 
+                python report.py -r ${_refer_job}_${_refer_sc} -t ${_target_job}_${_target_sc} -m ${thread} --md_off --url ${BUILD_URL} --precision ${_precision} --cppwrapper_gm --mt_interval_start ${_mt_start} --mt_interval_end ${_mt_end} --st_interval_start ${_st_start} --st_interval_end ${_st_end} --suite ${_suite} --infer_or_train ${_infer_or_train} --shape ${shape} --wrapper ${wrapper} --torch_repo ${torch_repo} --torch_branch ${torch_branch}  --backend ${backend} --threshold ${threshold} --ref_backend ${ref_backend} 
             else
-                python report.py -r ${_refer_job}_${_refer_sc} -t ${_target_job}_${_target_sc} -m all --md_off --url ${BUILD_URL} --precision ${_precision} --suite ${_suite} --infer_or_train ${_infer_or_train} --shape ${shape} --wrapper ${wrapper} --shape ${shape} --wrapper ${wrapper} --torch_repo ${torch_repo} --torch_branch ${torch_branch} --backend ${backend} --threshold ${threshold} --ref_backend ${ref_backend} 
+                python report.py -r ${_refer_job}_${_refer_sc} -t ${_target_job}_${_target_sc} -m ${thread} --md_off --url ${BUILD_URL} --precision ${_precision} --suite ${_suite} --infer_or_train ${_infer_or_train} --shape ${shape} --wrapper ${wrapper} --shape ${shape} --wrapper ${wrapper} --torch_repo ${torch_repo} --torch_branch ${torch_branch} --backend ${backend} --threshold ${threshold} --ref_backend ${ref_backend} 
             fi
             mv ${_target_job}_${_target_sc}/inductor_log/*.xlsx ./ && mv ${_target_job}_${_target_sc}/inductor_log/*.html ./
             '''

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -177,11 +177,11 @@ node(NODE_LABEL){
         checkout scm   
     }
     param_compare_flag = "SUCCESS"
-    error_email_msg = "Please double check in ${BUILD_URL}"
+    env.error_email_msg = "Please double check in ${BUILD_URL}"
     stage("parameter compare") {
         if ((_target_job == _refer_job) && (_target_sc == _refer_sc)){
             param_compare_flag = "FAILED"
-            error_email_msg = "Target job and Reference job are the same. " + error_email_msg
+            env.error_email_msg = "Target job and Reference job are the same. " + error_email_msg
         } else {
             def target_params = getUpstreamParameters(_target_job, _target_sc)
             def ref_params = getUpstreamParameters(_refer_job, _refer_sc)
@@ -189,7 +189,7 @@ node(NODE_LABEL){
             for (param_title in params_title_list) {
                 if (target_params.get(param_title) != ref_params.get(param_title)) {
                     param_compare_flag = "FAILED"
-                    error_email_msg = param_title + " is not same, target is " + target_params.get(param_title) + ". refer is " + ref_params.get(param_title) + ".\\n" + error_email_msg
+                    env.error_email_msg = param_title + " is not same, target is " + target_params.get(param_title) + ". refer is " + ref_params.get(param_title) + ".<br>" + error_email_msg
                 }
             }
         }
@@ -201,7 +201,7 @@ node(NODE_LABEL){
                 mimeType: "text/html",
                 from: "pytorch_inductor_val@intel.com",
                 to: maillist,
-                body: error_email_msg
+                body: """${error_email_msg}"""
             )
         }
     } else {

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -189,7 +189,7 @@ node(NODE_LABEL){
             for (param_title in params_title_list) {
                 if (target_params.get(param_title) != ref_params.get(param_title)) {
                     param_compare_flag = "FAILED"
-                    error_email_msg = param_title + "is not same, target is " + target_params.get(param_title) + "refer is " + ref_params.get(param_title) + ".\n" + error_email_msg
+                    error_email_msg = param_title + "is not same, target is " + target_params.get(param_title) + ". refer is " + ref_params.get(param_title) + ".\n" + error_email_msg
                 }
             }
         }

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -189,7 +189,7 @@ node(NODE_LABEL){
             for (param_title in params_title_list) {
                 if (target_params.get(param_title) != ref_params.get(param_title)) {
                     param_compare_flag = "FAILED"
-                    error_email_msg = param_title + "is not same, target is " + target_params.get(param_title) + ". refer is " + ref_params.get(param_title) + ".\n" + error_email_msg
+                    error_email_msg = param_title + " is not same, target is " + target_params.get(param_title) + ". refer is " + ref_params.get(param_title) + ".\n" + error_email_msg
                 }
             }
         }

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -219,6 +219,14 @@ node(NODE_LABEL){
 
             def ref_params = getUpstreamParameters(_refer_job, _refer_sc)
             env.ref_backend = ref_params.get('backend')
+            
+            def default_backend = "inductor"
+            if (env.backend == "null") {
+                env.backend = default_backend
+            }
+            if (env.ref_backend == "null") {
+                env.ref_backend = default_backend
+            }
             sh '''
             #!/usr/bin/env bash
             if [ ${_NODE} == 'mlp-spr-04.sh.intel.com' ];then

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -189,7 +189,7 @@ node(NODE_LABEL){
             for (param_title in params_title_list) {
                 if (target_params.get(param_title) != ref_params.get(param_title)) {
                     param_compare_flag = "FAILED"
-                    error_email_msg = param_title "is not same, target is " + target_params.get(param_title) + "refer is " + ref_params.get(param_title) + ".\n" + error_email_msg
+                    error_email_msg = param_title + "is not same, target is " + target_params.get(param_title) + "refer is " + ref_params.get(param_title) + ".\n" + error_email_msg
                 }
             }
         }

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -161,6 +161,12 @@ def getUpstreamParameters(String job_name, String job_id) {
     return params
 }
 
+if ("${debug}" == "true"){
+    maillist="${debug_mail}"
+}else{
+    maillist="Chuanqi.Wang@intel.com;guobing.chen@intel.com;beilei.zheng@intel.com;xiangdong.zeng@intel.com;xuan.liao@intel.com;Chunyuan.Wu@intel.com;Haozhe.Zhu@intel.com;weiwen.xia@intel.com;jiong.gong@intel.com;eikan.wang@intel.com;fan.zhao@intel.com;shufan.wu@intel.com;weizhuo.zhang@intel.com;yudong.si@intel.com;diwei.sun@intel.com"
+}
+
 node(NODE_LABEL){
     stage("prepare"){
         echo 'prepare......'
@@ -235,11 +241,6 @@ node(NODE_LABEL){
         }
 
         stage("Email"){
-            if ("${debug}" == "true"){
-                maillist="${debug_mail}"
-            }else{
-                maillist="Chuanqi.Wang@intel.com;guobing.chen@intel.com;beilei.zheng@intel.com;xiangdong.zeng@intel.com;xuan.liao@intel.com;Chunyuan.Wu@intel.com;Haozhe.Zhu@intel.com;weiwen.xia@intel.com;jiong.gong@intel.com;eikan.wang@intel.com;fan.zhao@intel.com;shufan.wu@intel.com;weizhuo.zhang@intel.com;yudong.si@intel.com;diwei.sun@intel.com"
-            }
             if (fileExists("${WORKSPACE}/inductor_model_bench.html") == true){
                 emailext(
                     subject: "[report-compare]-${env._target_job}-${env._refer_job}",

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -149,7 +149,10 @@ env._NODE = "$NODE_LABEL"
 def getUpstreamParameters(String job_name, String job_id) {
     def params = [:]
     try {
-        def upstream_job = Jenkins.getInstance().getItemByFullName(job_name).getBuildByNumber(job_id.toInteger())
+        def upstream_job = Jenkins.getInstance().getItemByFullName(job_name).getLastSuccessfulBuild()
+        if (job_id != "lastSuccessfulBuild") {
+            upstream_job = Jenkins.getInstance().getItemByFullName(job_name).getBuildByNumber(job_id.toInteger())
+        }
         def param_list = upstream_job.actions.find{ a -> a instanceof ParametersAction }?.parameters
 
         param_list.each { p ->

--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -177,11 +177,11 @@ node(NODE_LABEL){
         checkout scm   
     }
     param_compare_flag = "SUCCESS"
-    error_email_msg = "Null"
+    error_email_msg = "Please double check in ${BUILD_URL}"
     stage("parameter compare") {
         if ((_target_job == _refer_job) && (_target_sc == _refer_sc)){
             param_compare_flag = "FAILED"
-            error_email_msg = "Target job and Reference job are the same, please double check in ${BUILD_URL}"
+            error_email_msg = "Target job and Reference job are the same. " + error_email_msg
         } else {
             def target_params = getUpstreamParameters(_target_job, _target_sc)
             def ref_params = getUpstreamParameters(_refer_job, _refer_sc)
@@ -189,7 +189,7 @@ node(NODE_LABEL){
             for (param_title in params_title_list) {
                 if (target_params.get(param_title) != ref_params.get(param_title)) {
                     param_compare_flag = "FAILED"
-                    error_email_msg = param_title + " is not same, target is " + target_params.get(param_title) + ". refer is " + ref_params.get(param_title) + ".\n" + error_email_msg
+                    error_email_msg = param_title + " is not same, target is " + target_params.get(param_title) + ". refer is " + ref_params.get(param_title) + ".\\n" + error_email_msg
                 }
             }
         }


### PR DESCRIPTION
- **Bug 1:** `target_job == refer_job` and `target_id` == `refer_id`.
  - Solution: Email with content **Target job and Reference job are the same**.
  - [x] **Test job link:** https://inteltf-jenk.sh.intel.com/user/weizhuo/my-views/view/weizhuoz_view/job/inductor_job_result_compare_zwz/21/
<img src="https://github.com/chuanqi129/inductor-tools/assets/84730719/6e4d9655-54fa-407f-95dc-e3b73e580a53" height="200" />

- **Bug 2:** `job_id` is `lastSuccessfulBuild` which cannot be read by function `getUpstreamParameters`. 
  - Solution: Fixed in function `getUpstreamParameters`

- **Bug 3:** `backend` parameter is `null` in our regular job. 
  - Solution: If `backend` is null, we set it as `inductor` as default.
  - [x] **Test job link:** https://inteltf-jenk.sh.intel.com/user/weizhuo/my-views/view/weizhuoz_view/job/inductor_job_result_compare_zwz/22/

- **Bug 3:** default `THREADS` is all
  - Solution: read `THREADS` from `target_job`

- **Bug 4:** `target_job` parameters are not same as `refer_job`
  - Solution: If one of those parameters `['shape', 'WRAPPER', 'suite', 'precision', 'THREADS']` are not the same, the job will be regarded as failed job.
 - [x] **Test job link:** https://inteltf-jenk.sh.intel.com/user/weizhuo/my-views/view/weizhuoz_view/job/inductor_job_result_compare_zwz/19/
<img src="https://github.com/chuanqi129/inductor-tools/assets/84730719/cb61318f-a367-4856-9c2e-a1c69686c12f" />
