### PR TITLE
fix AOT refer report

### DIFF
--- a/groovy/inductor_locally_benchmark.groovy
+++ b/groovy/inductor_locally_benchmark.groovy
@@ -280,6 +280,7 @@ node(NODE_LABEL){
                         --wrapper ${WRAPPER} \
                         --torch_repo ${TORCH_REPO} \
                         --backend ${backend} \
+                        --ref_backend ${backend} \
                         ${dashboard_args}
                     rm -rf refer
                 '''


### PR DESCRIPTION
**Description:**
`refer_backend` default value is `inductor`, so for AOT inductor case, we need to pass `refer_backend` value.