### PR TITLE
fix guilty commit image build bug

### DIFF
--- a/groovy/inductor_locally_guilty_commit.groovy
+++ b/groovy/inductor_locally_guilty_commit.groovy
@@ -62,7 +62,7 @@ node(us_node) {
             cd ${WORKSPACE}
             git clone ${TORCH_REPO}
             cd pytorch
-            git checkout ${TORCH_START_COMMIT}
+            git checkout ${TORCH_END_COMMIT}
             commit_date=`git log -n 1 --format="%cs"`
             bref_commit=`git rev-parse --short HEAD`
             DOCKER_TAG="${commit_date}_${bref_commit}"


### PR DESCRIPTION
Issue:
We should build guilty-commit image based on `TORCH_END_COMMIT`, not `TORCH_START_COMMIE`
https://github.com/chuanqi129/inductor-tools/blob/a4db432c00eef9b2bce3be910d13f70cc2416a69/scripts/modelbench/bisect_search.sh#L46-L47