### PR TITLE
Local guilty commit bug fix and optimization

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ RUN curl -fsSL -v -k -o ~/miniforge.sh -O https://github.com/conda-forge/minifor
         cffi \
         cython \
         cmake=3.26 \
+        mamba=1.5.8 \
         dataclasses \
         future \
         git-lfs \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN curl -fsSL -v -k -o ~/miniforge.sh -O https://github.com/conda-forge/minifor
         astunparse \
         cffi \
         cython \
-        cmake>=3.13.0 \
+        cmake=3.26 \
         dataclasses \
         future \
         git-lfs \

--- a/groovy/inductor_locally_guilty_commit.groovy
+++ b/groovy/inductor_locally_guilty_commit.groovy
@@ -62,7 +62,7 @@ node(us_node) {
             cd ${WORKSPACE}
             git clone ${TORCH_REPO}
             cd pytorch
-            git checkout ${TORCH_START_COMMIT}
+            git checkout ${TORCH_END_COMMIT}
             commit_date=`git log -n 1 --format="%cs"`
             bref_commit=`git rev-parse --short HEAD`
             DOCKER_TAG="${commit_date}_${bref_commit}"

--- a/groovy/inductor_locally_guilty_commit.groovy
+++ b/groovy/inductor_locally_guilty_commit.groovy
@@ -8,6 +8,8 @@ if (env.NODE_LABEL == "0") {
         env.NODE_LABEL = "inductor-icx-local"
     } else if (env.precision == 'amp') {
         env.NODE_LABEL = "inductor-gnr-local"
+    }else if (env.precision == 'amp_fp16') {
+        env.NODE_LABEL = "inductor-gnr-local"
     }
 }
 

--- a/groovy/inductor_locally_guilty_commit.groovy
+++ b/groovy/inductor_locally_guilty_commit.groovy
@@ -151,7 +151,6 @@ node(NODE_LABEL){
                 KIND=$kind \
                 THREADS=$THREADS \
                 CHANNELS=$CHANNELS \
-                FREEZE=on \
                 BS=0 \
                 LOG_DIR=$LOG_DIR \
                 HF_TOKEN=$HF_TOKEN \

--- a/groovy/inductor_locally_guilty_commit.groovy
+++ b/groovy/inductor_locally_guilty_commit.groovy
@@ -129,7 +129,8 @@ node(NODE_LABEL){
         sh '''
             #!/usr/bin/env bash
             docker_image_tag=`cat ${target}/${LOG_DIR}/docker_image_tag.log`
-            docker run -tid --name $USER \
+            container_name=pytorch
+            docker run -tid --name ${container_name} \
                 --privileged \
                 --env https_proxy=${https_proxy} \
                 --env http_proxy=${http_proxy} \
@@ -138,11 +139,11 @@ node(NODE_LABEL){
                 -v ~/.cache:/root/.cache \
                 -v ${WORKSPACE}/${target}/${LOG_DIR}:/workspace/pytorch/${LOG_DIR} \
                 ${DOCKER_IMAGE_NAMESPACE}:${docker_image_tag}
-            docker cp scripts/modelbench/bisect_search.sh $USER:/workspace/pytorch
-            docker cp scripts/modelbench/bisect_run_test.sh $USER:/workspace/pytorch
-            docker cp scripts/modelbench/inductor_single_run.sh $USER:/workspace/pytorch
+            docker cp scripts/modelbench/bisect_search.sh ${container_name}:/workspace/pytorch
+            docker cp scripts/modelbench/bisect_run_test.sh ${container_name}:/workspace/pytorch
+            docker cp scripts/modelbench/inductor_single_run.sh ${container_name}:/workspace/pytorch
             # TODO: Hard code freeze on and default bs, add them as params future
-            docker exec -i $USER bash -c "bash bisect_search.sh \
+            docker exec -i ${container_name} bash -c "bash bisect_search.sh \
                 START_COMMIT=$TORCH_START_COMMIT \
                 END_COMMIT=$TORCH_END_COMMIT \
                 SUITE=$suite \
@@ -163,7 +164,7 @@ node(NODE_LABEL){
                 EXTRA=$extra_param" \
                 > ${WORKSPACE}/${target}/${LOG_DIR}/docker_exec_detailed.log
 
-            docker exec -i $USER bash -c "chmod 777 -R /workspace/pytorch/${LOG_DIR}"
+            docker exec -i ${container_name} bash -c "chmod 777 -R /workspace/pytorch/${LOG_DIR}"
         '''
     }
 

--- a/groovy/inductor_locally_guilty_commit.groovy
+++ b/groovy/inductor_locally_guilty_commit.groovy
@@ -62,7 +62,11 @@ node(us_node) {
             cd ${WORKSPACE}
             git clone ${TORCH_REPO}
             cd pytorch
-            git checkout ${TORCH_END_COMMIT}
+            # Local will re-use docker image which it's built before
+            # Local guilty commit will use START_COMMIT to build image, which will contain END_COMMIT
+            # If we are using END_COMMIT, the old END_COMMIT docker image pytorch repo did not contain new START_COMMIT
+            # Will report fatal: reference is not a tree: START_COMMIT
+            git checkout ${TORCH_START_COMMIT}
             commit_date=`git log -n 1 --format="%cs"`
             bref_commit=`git rev-parse --short HEAD`
             DOCKER_TAG="${commit_date}_${bref_commit}"

--- a/scripts/modelbench/bisect_run_test.sh
+++ b/scripts/modelbench/bisect_run_test.sh
@@ -21,7 +21,7 @@ prepare_test() {
     git reset --hard HEAD && git submodule sync && git submodule update --init --recursive
     python setup.py clean && python setup.py develop && cd .. && \
     cd vision && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt` && pip uninstall torchvision -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
+    # cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd text && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/text.txt` && pip uninstall torchtext -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     export TRANSFORMERS_COMMIT=`cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && pip install --force-reinstall git+https://github.com/huggingface/transformers@${TRANSFORMERS_COMMIT}

--- a/scripts/modelbench/bisect_run_test.sh
+++ b/scripts/modelbench/bisect_run_test.sh
@@ -23,7 +23,7 @@ prepare_test() {
     cd vision && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt` && pip uninstall torchvision -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     # cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd text && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/text.txt` && pip uninstall torchtext -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
+    # cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     export TRANSFORMERS_COMMIT=`cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && pip install --force-reinstall git+https://github.com/huggingface/transformers@${TRANSFORMERS_COMMIT}
     cd benchmark && git checkout main && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/torchbench.txt` && cd /workspace/pytorch
 }

--- a/scripts/modelbench/bisect_run_test.sh
+++ b/scripts/modelbench/bisect_run_test.sh
@@ -10,12 +10,11 @@ SCENARIO=${7:-accuracy} # accuracy / performance
 KIND=${8:-drop} # crash / drop / fixed / improve
 THREADS=${9:-multiple} # multiple / single
 CHANNELS=${10:-first} # first / last
-FREEZE=${11:-on} # on / off
-BS=${12:-0} # default / specific
-EXP_PERF=${13:-0}
-BACKEND=${14:-inductor}
-PERF_RATIO=${15:-1.1} # default 10% perforamnce drop regard as issue
-EXTRA=${16}
+BS=${11:-0} # default / specific
+EXP_PERF=${12:-0}
+BACKEND=${13:-inductor}
+PERF_RATIO=${14:-1.1} # default 10% perforamnce drop regard as issue
+EXTRA=${15}
 
 prepare_test() {
     rm -rf /tmp/*
@@ -30,7 +29,7 @@ prepare_test() {
 }
 
 run_perf_drop_test() {
-    detected_value=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $FREEZE $BACKEND | tail -n 1 | awk -F, '{print $5}')
+    detected_value=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $BACKEND | tail -n 1 | awk -F, '{print $5}')
     result=$(echo $detected_value | awk '{ printf "%.5f", $1/1000 }')
     echo "=====result: $result======="
     ratio=$(echo "$result $EXP_PERF" | awk '{ printf "%.2f\n", $1/$2 }')
@@ -45,7 +44,7 @@ run_perf_drop_test() {
 }
 
 run_perf_improve_test() {
-    detected_value=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $FREEZE $BACKEND | tail -n 1 | awk -F, '{print $5}')
+    detected_value=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $BACKEND | tail -n 1 | awk -F, '{print $5}')
     result=$(echo $detected_value | awk '{ printf "%.5f", $1/1000 }')
     echo "=====result: $result======="
     ratio=$(echo "$EXP_PERF $result" | awk '{ printf "%.2f\n", $1/$2 }')
@@ -60,7 +59,7 @@ run_perf_improve_test() {
 }
 
 run_acc_drop_test() {
-    acc_res=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $FREEZE $BACKEND | tail -n 1 | awk -F, '{print $4}')
+    acc_res=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $BACKEND | tail -n 1 | awk -F, '{print $4}')
     echo "=====acc: $acc_res======="
     if [ "X$acc_res" != "Xpass" ]; then
 	    echo "`git rev-parse HEAD` is a BAD COMMIT!"
@@ -72,7 +71,7 @@ run_acc_drop_test() {
 }
 
 run_acc_improve_test() {
-    acc_res=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $FREEZE $BACKEND | tail -n 1 | awk -F, '{print $4}')
+    acc_res=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $BACKEND | tail -n 1 | awk -F, '{print $4}')
     echo "=====acc: $acc_res======="
     if [ "X$acc_res" != "Xpass" ]; then
 	    echo "`git rev-parse HEAD` is a BAD COMMIT!"
@@ -84,7 +83,7 @@ run_acc_improve_test() {
 }
 
 run_crash_test() {
-    bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $FREEZE $BACKEND 2>&1 | tee ./crash.log
+    bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $BACKEND 2>&1 | tee ./crash.log
     if [ $? -eq 0 ]; then
         acc_status=`tail -n 1 ./crash.log | grep pass | wc -l`
         perf_status=`tail -n 1 ./crash.log | grep $MODEL | awk -F, '{print $3}'`
@@ -114,7 +113,7 @@ run_crash_test() {
 }
 
 run_fixed_test() {
-    bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $FREEZE $BACKEND 2>&1 | tee ./fixed.log
+    bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $DT $CHANNELS $SHAPE $WRAPPER $BS $BACKEND 2>&1 | tee ./fixed.log
     if [ $? -eq 0 ]; then
         acc_status=`tail -n 1 ./fixed.log | grep pass | wc -l`
         perf_status=`tail -n 1 ./fixed.log | grep $MODEL | awk -F, '{print $3}'`

--- a/scripts/modelbench/bisect_search.sh
+++ b/scripts/modelbench/bisect_search.sh
@@ -58,7 +58,7 @@ if [ "$SCENARIO" == "performance" ] && ([ "$KIND" == "drop" ] || [ "$KIND" == "i
     cd vision && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt` && pip uninstall torchvision -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     # cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd text && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/text.txt` && pip uninstall torchtext -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
+    # cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     export TRANSFORMERS_COMMIT=`cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && pip install --force-reinstall git+https://github.com/huggingface/transformers@${TRANSFORMERS_COMMIT} && cd /workspace/pytorch
     detected_value=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $PRECISION $CHANNELS $SHAPE $WRAPPER $BS $BACKEND | tail -n 1 | awk -F, '{print $5}')
     current_perf=$(echo $detected_value | awk '{ printf "%.5f", $1/1000 }')

--- a/scripts/modelbench/bisect_search.sh
+++ b/scripts/modelbench/bisect_search.sh
@@ -46,12 +46,7 @@ if [ "$SCENARIO" == "performance" ] && ([ "$KIND" == "drop" ] || [ "$KIND" == "i
     # Local: Initial image build with START_COMMIT, local need to rebuild with END_COMMIT.
     rm -rf /tmp/*
     git reset --hard HEAD && git checkout ${END_COMMIT} && git submodule sync && git submodule update --init --recursive
-    python setup.py clean && python setup.py develop && cd .. && \
-    cd vision && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt` && pip uninstall torchvision -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    cd text && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/text.txt` && pip uninstall torchtext -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    export TRANSFORMERS_COMMIT=`cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && pip install --force-reinstall git+https://github.com/huggingface/transformers@${TRANSFORMERS_COMMIT} && cd /workspace/pytorch
+    python setup.py clean && python setup.py develop 
     detected_value=$(bash ./inductor_single_run.sh $THREADS $MODE $SCENARIO $SUITE $MODEL $PRECISION $CHANNELS $SHAPE $WRAPPER $BS $BACKEND | tail -n 1 | awk -F, '{print $5}')
     expected_perf=$(echo $detected_value | awk '{ printf "%.5f", $1/1000 }')
     echo "Expected performance: $expected_perf s" > ${LOG_DIR}/perf_drop.log

--- a/scripts/modelbench/bisect_search.sh
+++ b/scripts/modelbench/bisect_search.sh
@@ -44,7 +44,8 @@ expected_perf=0
 if [ "$SCENARIO" == "performance" ] && ([ "$KIND" == "drop" ] || [ "$KIND" == "improve" ]); then
     # AWS: Initial image build with END_COMMIT, no need rebuild, because AWS will always build new image every time
     # Local: Initial image build with START_COMMIT, local need to rebuild with END_COMMIT.
-    git checkout ${END_COMMIT} && git submodule sync && git submodule update --init --recursive
+    rm -rf /tmp/*
+    git reset --hard HEAD && git checkout ${END_COMMIT} && git submodule sync && git submodule update --init --recursive
     python setup.py clean && python setup.py develop && cd .. && \
     cd vision && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt` && pip uninstall torchvision -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \

--- a/scripts/modelbench/bisect_search.sh
+++ b/scripts/modelbench/bisect_search.sh
@@ -56,7 +56,7 @@ if [ "$SCENARIO" == "performance" ] && ([ "$KIND" == "drop" ] || [ "$KIND" == "i
     git reset --hard HEAD && git checkout ${START_COMMIT} && git submodule sync && git submodule update --init --recursive
     python setup.py clean && python setup.py develop && cd .. && \
     cd vision && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/vision.txt` && pip uninstall torchvision -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
-    cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
+    # cd data && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/data.txt`  && pip uninstall torchdata -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd text && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/text.txt` && pip uninstall torchtext -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     cd audio && git checkout `cat /workspace/pytorch/.github/ci_commit_pins/audio.txt` && pip uninstall torchaudio -y && python setup.py bdist_wheel && pip install dist/*.whl && cd .. && \
     export TRANSFORMERS_COMMIT=`cat /workspace/pytorch/.ci/docker/ci_commit_pins/huggingface.txt` && pip install --force-reinstall git+https://github.com/huggingface/transformers@${TRANSFORMERS_COMMIT} && cd /workspace/pytorch

--- a/scripts/modelbench/inductor_single_run.sh
+++ b/scripts/modelbench/inductor_single_run.sh
@@ -43,7 +43,7 @@ if [[ "$DT" == "amp_fp16" ]]; then
     DT_extra="--amp-dtype float16 "
 fi
 
-cd /benchmarks/dynamo
+cd ./benchmarks/dynamo
 if [[ $BACKEND == "aot_inductor" ]]; then
     # Workaround for test with runner.py
     sed -i '/"inference": {/a \ \ \ \ \ \ \ \ "aot_inductor": "--inference -n50 --export-aot-inductor ",' runner.py    

--- a/scripts/modelbench/inductor_single_run.sh
+++ b/scripts/modelbench/inductor_single_run.sh
@@ -13,8 +13,7 @@ CHANNELS=${7:-first} # first / last
 SHAPE=${8:-static} # static / dynamic
 WRAPPER=${9:-default} # default / cpp
 BS=${10:-0}
-FREEZE=${11:-on}
-BACKEND=${12:-inductor}
+BACKEND=${11:-inductor}
 
 Mode_extra="--inference "
 if [[ $MODE == "training" ]]; then
@@ -51,11 +50,22 @@ if [[ "$DT" == "amp_fp16" ]]; then
 fi
 
 Flag_extra=""
-if [[ ${FREEZE} == "on" ]]; then
+if [[ $BACKEND == "aot_inductor" ]]; then
+    echo "Testing with aot_inductor."
+    # Workaround for test with runner.py
+    sed -i '/"inference": {/a \ \ \ \ \ \ \ \ "aot_inductor": "--inference -n50 --export-aot-inductor ",' benchmarks/dynamo/runner.py
+    echo "Setting freezing for inductor backend by default."
     export TORCHINDUCTOR_FREEZING=1
-    echo "Testing with freezing on."
-    Flag_extra="--freezing " 
-fi 
+    Flag_extra+="--freezing --export-aot-inductor "
+elif [[ $BACKEND == "inductor" ]]; then
+    echo "Setting freezing for inductor backend by default."
+    export TORCHINDUCTOR_FREEZING=1
+    Flag_extra+="--freezing --${BACKEND} "
+elif [[ $BACKEND == "inductor_max_autotune" ]]; then
+    echo "Setting freezing for inductor with max autotune by default."
+    export TORCHINDUCTOR_FREEZING=1
+    Flag_extra+="--freezing --inductor --inductor-compile-mode max-autotune "
+fi
 
 cpu_allowed_list=$(cat /proc/self/status | grep Cpus_allowed_list | awk '{print $2}')
 start_core=$(echo ${cpu_allowed_list} | awk -F- '{print $1}')
@@ -73,13 +83,13 @@ fi
 multi_threads_test() {
     export OMP_NUM_THREADS=$CORES
     end_core=$(expr $CORES - 1)    
-    numactl -C ${cpu_allowed_list} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu -n50 --no-skip --dashboard --only "${MODEL}" ${Channels_extra} ${BS_extra} ${Shape_extra} ${Mode_extra} ${Flag_extra} ${DT_extra} --timeout 9000 --backend=${BACKEND}  --output=/tmp/inductor_single_test_mt.csv && \
+    numactl -C ${cpu_allowed_list} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu -n50 --no-skip --dashboard --only "${MODEL}" ${Channels_extra} ${BS_extra} ${Shape_extra} ${Mode_extra} ${Flag_extra} ${DT_extra} --timeout 9000 --output=/tmp/inductor_single_test_mt.csv && \
     cat /tmp/inductor_single_test_mt.csv && rm /tmp/inductor_single_test_mt.csv
 }
 
 single_thread_test() {
     export OMP_NUM_THREADS=1
-    numactl -C ${start_core}-${start_core} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu -n50 --no-skip --dashboard --batch-size 1 --threads 1 --only "${MODEL}" ${Channels_extra} ${Shape_extra} ${Mode_extra} ${Flag_extra} ${DT_extra} --timeout 9000 --backend=${BACKEND}  --output=/tmp/inductor_single_test_st.csv && \
+    numactl -C ${start_core}-${start_core} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu -n50 --no-skip --dashboard --batch-size 1 --threads 1 --only "${MODEL}" ${Channels_extra} ${Shape_extra} ${Mode_extra} ${Flag_extra} ${DT_extra} --timeout 9000 --output=/tmp/inductor_single_test_st.csv && \
     cat /tmp/inductor_single_test_st.csv && rm /tmp/inductor_single_test_st.csv
 }
 

--- a/scripts/modelbench/inductor_single_run.sh
+++ b/scripts/modelbench/inductor_single_run.sh
@@ -43,24 +43,21 @@ if [[ "$DT" == "amp_fp16" ]]; then
     DT_extra="--amp-dtype float16 "
 fi
 
-Flag_extra=""
 cd /workspace/pytorch/benchmarks/dynamo
 if [[ $BACKEND == "aot_inductor" ]]; then
-    echo "Testing with aot_inductor."
     # Workaround for test with runner.py
-    sed -i '/"inference": {/a \ \ \ \ \ \ \ \ "aot_inductor": "--inference -n50 --export-aot-inductor ",' runner.py
-    echo "Setting freezing for inductor backend by default."
-    export TORCHINDUCTOR_FREEZING=1
-    Flag_extra+="--freezing $(python -c "import runner; print(runner.TABLE['${MODE}']['${BACKEND}'])") "
-elif [[ $BACKEND == "inductor" ]]; then
-    echo "Setting freezing for inductor backend by default."
-    export TORCHINDUCTOR_FREEZING=1
-    Flag_extra+="--freezing $(python -c "import runner; print(runner.TABLE['${MODE}']['${BACKEND}'])") "
-elif [[ $BACKEND == "inductor_max_autotune" ]]; then
-    echo "Setting freezing for inductor with max autotune by default."
-    export TORCHINDUCTOR_FREEZING=1
-    Flag_extra+="--freezing $(python -c "import runner; print(runner.TABLE['${MODE}']['${BACKEND}'])") "
+    sed -i '/"inference": {/a \ \ \ \ \ \ \ \ "aot_inductor": "--inference -n50 --export-aot-inductor ",' runner.py    
 fi
+
+echo "Testing with ${BACKEND}."
+Backend_extra="$(python -c "import runner; print(runner.TABLE['${MODE}']['${BACKEND}'])") "
+
+Flag_extra=""
+if [[ ${MODE} == "inference" ]]; then
+    export TORCHINDUCTOR_FREEZING=1
+    Flag_extra+="--freezing "
+fi
+
 cd /workspace/pytorch
 
 cpu_allowed_list=$(cat /proc/self/status | grep Cpus_allowed_list | awk '{print $2}')
@@ -79,13 +76,13 @@ fi
 multi_threads_test() {
     export OMP_NUM_THREADS=$CORES
     end_core=$(expr $CORES - 1)    
-    numactl -C ${cpu_allowed_list} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu --no-skip --dashboard --only "${MODEL}" ${Channels_extra} ${BS_extra} ${Shape_extra} ${Flag_extra} ${DT_extra} --timeout 9000 --output=/tmp/inductor_single_test_mt.csv && \
+    numactl -C ${cpu_allowed_list} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu --no-skip --dashboard --only "${MODEL}" ${Channels_extra} ${BS_extra} ${Shape_extra} ${Flag_extra} ${Backend_extra} ${DT_extra} --timeout 9000 --output=/tmp/inductor_single_test_mt.csv && \
     cat /tmp/inductor_single_test_mt.csv && rm /tmp/inductor_single_test_mt.csv
 }
 
 single_thread_test() {
     export OMP_NUM_THREADS=1
-    numactl -C ${start_core}-${start_core} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu --no-skip --dashboard --batch-size 1 --threads 1 --only "${MODEL}" ${Channels_extra} ${Shape_extra} ${Flag_extra} ${DT_extra} --timeout 9000 --output=/tmp/inductor_single_test_st.csv && \
+    numactl -C ${start_core}-${start_core} --membind=${mem_allowed_list} python benchmarks/dynamo/${SUITE}.py --${SCENARIO} --${DT} -dcpu --no-skip --dashboard --batch-size 1 --threads 1 --only "${MODEL}" ${Channels_extra} ${Shape_extra} ${Flag_extra} ${Backend_extra} ${DT_extra} --timeout 9000 --output=/tmp/inductor_single_test_st.csv && \
     cat /tmp/inductor_single_test_st.csv && rm /tmp/inductor_single_test_st.csv
 }
 

--- a/scripts/modelbench/inductor_single_run.sh
+++ b/scripts/modelbench/inductor_single_run.sh
@@ -43,7 +43,7 @@ if [[ "$DT" == "amp_fp16" ]]; then
     DT_extra="--amp-dtype float16 "
 fi
 
-cd /workspace/pytorch/benchmarks/dynamo
+cd /benchmarks/dynamo
 if [[ $BACKEND == "aot_inductor" ]]; then
     # Workaround for test with runner.py
     sed -i '/"inference": {/a \ \ \ \ \ \ \ \ "aot_inductor": "--inference -n50 --export-aot-inductor ",' runner.py    
@@ -58,7 +58,7 @@ if [[ ${MODE} == "inference" ]]; then
     Flag_extra+="--freezing "
 fi
 
-cd /workspace/pytorch
+cd ../..
 
 cpu_allowed_list=$(cat /proc/self/status | grep Cpus_allowed_list | awk '{print $2}')
 start_core=$(echo ${cpu_allowed_list} | awk -F- '{print $1}')


### PR DESCRIPTION
**Optimization:**

- [x] Enabled all support backend for guilty commit search
- [x] Remove `FREEZE` parameter which will be controlled by `backend` parameter
- [x] Use benchmarks/dynamo/runner.py TABLE for backend command line options

**Bug fix:**

- [x] Fix local guilty commit search bug: previously, local guilty commit search job only checked out END_COMMIT, but pytorch version in docker is still be START_COMMIT.

**Before fix:**
END_COMMIT will fail for first time try test expect performance: https://inteltf-jenk.sh.intel.com/job/inductor_local_guilty_commit_search/145
![image](https://github.com/user-attachments/assets/35da0a02-3f4b-46ec-b25e-f5f63041bce6)


**After fix:**
END_COMMIT success for first time try test.: https://inteltf-jenk.sh.intel.com/job/inductor_local_guilty_commit_search_zwz/6
![image](https://github.com/user-attachments/assets/e0106e02-01ed-4258-a33b-1c3cc1afd148)
