### PR TITLE
fix dependency issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ RUN curl -fsSL -v -k -o ~/miniforge.sh -O https://github.com/conda-forge/minifor
         cffi \
         cython \
         cmake=3.26 \
+        mamba=1.5.8 \
         dataclasses \
         future \
         git-lfs \


### PR DESCRIPTION
#10 49.59 * Connection #1 to host objects.githubusercontent.com left intact #10 49.59
#10 49.59 LibMambaUnsatisfiableError: Encountered problems while solving:
#10 49.59   - package libmambapy-1.5.9-py39h585447c_0 requires python_abi 3.9 *_pypy39_pp73, but none of the providers can be installed
#10 49.59
#10 49.59 Could not solve for environment specs
#10 49.59 The following packages are incompatible
#10 49.59 ├─ mamba >=1.5.9  is installable with the potential options
#10 49.59 │  ├─ mamba 1.5.9 would require
#10 49.59 │  │  └─ libmambapy 1.5.9 py39h585447c_0, which requires
#10 49.59 │  │     └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
#10 49.59 │  ├─ mamba 1.5.9 would require
#10 49.59 │  │  └─ python_abi 3.12.* *_cp312, which can be installed;
#10 49.59 │  ├─ mamba 1.5.9 would require
#10 49.59 │  │  └─ libmambapy 1.5.9 py310h86cbe3b_0, which requires
#10 49.59 │  │     ├─ python >=3.10,<3.11.0a0 , which can be installed;
#10 49.59 │  │     └─ python_abi 3.10.* *_cp310, which can be installed;
#10 49.59 │  ├─ mamba 1.5.9 would require
#10 49.59 │  │  └─ libmambapy 1.5.9 py311h7f1ffb1_0, which requires
#10 49.59 │  │     ├─ python >=3.11,<3.12.0a0 , which can be installed;
#10 49.59 │  │     └─ python_abi 3.11.* *_cp311, which can be installed;
#10 49.59 │  └─ mamba 1.5.9 would require
#10 49.59 │     └─ libmambapy 1.5.9 py39h27b6755_0, which requires
#10 49.59 │        ├─ python >=3.9,<3.10.0a0 , which can be installed;
#10 49.59 │        └─ python_abi 3.9.* *_cp39, which can be installed;
#10 49.59 └─ python 3.8**  is not installable because it conflicts with any installable versions previously reported.
#10 49.59
#10 ERROR: process "/bin/sh -c curl -fsSL -v -k -o ~/miniforge.sh -O https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh &&     chmod +x ~/miniforge.sh &&     ~/miniforge.sh -b -p /opt/conda &&     rm ~/miniforge.sh &&     /opt/conda/bin/conda install -y python=${PYTHON_VERSION}         astunparse         cffi         cython         cmake=3.26         dataclasses         future         git-lfs         ipython         mkl         mkl-include         ninja         numpy         requests         typing         typing_extensions         Pillow         pkg-config         pybind11         pyyaml         setuptools         jemalloc         openssl         weasyprint &&     /opt/conda/bin/conda clean -ya &&     rm -f /opt/conda/lib/libstdc++.so.6" did not complete successfully: exit code: 1
------