### PR TITLE
Update the Conda channel

### DIFF
--- a/docker/Dockerfile.dind
+++ b/docker/Dockerfile.dind
@@ -34,7 +34,7 @@ RUN curl -fsSL -v -k -o ~/miniforge.sh -O https://github.com/conda-forge/minifor
     ~/miniforge.sh -b -p /opt/conda && \
     rm ~/miniforge.sh && \
     /opt/conda/bin/conda config --set channel_priority strict && \
-    /opt/conda/bin/conda config --append channels intel && \
+    /opt/conda/bin/conda config --append channels https://software.repos.intel.com/python/conda/ && \
     /opt/conda/bin/conda install -y python=${PYTHON_VERSION} \
         astunparse \
         cffi \


### PR DESCRIPTION
Since the Intel Conda channel is no longer available, use the Intel repository instead.