### PR TITLE
fix job compare issue for fp16

### DIFF
--- a/groovy/inductor_job_compare.groovy
+++ b/groovy/inductor_job_compare.groovy
@@ -253,9 +253,6 @@ node(NODE_LABEL){
             fi
             # Install dependencies
             pip install scipy datacompy PyGithub styleframe pandas bs4 requests
-            if [ "${_precision}" == "amp_fp16" ];then
-                export _precision='amp'
-            fi
             cp scripts/modelbench/report.py ${WORKSPACE}
             if [ ${_cppwp_gm} == 'True' ];then
                 python report.py -r ${_refer_job}_${_refer_sc} -t ${_target_job}_${_target_sc} -m ${thread} --md_off --url ${BUILD_URL} --precision ${_precision} --cppwrapper_gm --mt_interval_start ${_mt_start} --mt_interval_end ${_mt_end} --st_interval_start ${_st_start} --st_interval_end ${_st_end} --suite ${_suite} --infer_or_train ${_infer_or_train} --shape ${shape} --wrapper ${wrapper} --torch_repo ${torch_repo} --torch_branch ${torch_branch}  --backend ${backend} --threshold ${threshold} --ref_backend ${ref_backend} 

--- a/scripts/modelbench/report.py
+++ b/scripts/modelbench/report.py
@@ -126,11 +126,12 @@ def percentage(part, whole, decimals=2):
 
 def update_passrate_csv(df, target_path, backend):
     new_df = df.copy()
+    precision = "amp" if args.precision == "amp_fp16" else args.precision
     for suite_name in suite_list:
         passrate_str = new_df.loc[backend][suite_name]
         passed_num = int(passrate_str.split(', ')[1].split('/')[0])
-        perf_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(target_path, backend, suite_name, args.precision, args.infer_or_train)
-        acc_path = '{0}/{1}_{2}_{3}_{4}_cpu_accuracy.csv'.format(target_path, backend, suite_name, args.precision, args.infer_or_train)
+        perf_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(target_path, backend, suite_name, precision, args.infer_or_train)
+        acc_path = '{0}/{1}_{2}_{3}_{4}_cpu_accuracy.csv'.format(target_path, backend, suite_name, precision, args.infer_or_train)
         perf_df = pd.read_csv(perf_path)
         acc_df = pd.read_csv(acc_path)
         acc_df = acc_df.drop(acc_df[(acc_df['accuracy'] == 'model_fail_to_load') | (acc_df['accuracy'] == 'eager_fail_to_run')].index)
@@ -359,6 +360,7 @@ def failures_reason_parse(model, acc_or_perf, mode):
     return line
 
 def get_failures(target_path, thread_mode, backend_pattern):
+    precision = "amp" if args.precision == "amp_fp16" else args.precision
     all_model_df = pd.DataFrame()
     failure_msg_list = [
         'fail_to_run',
@@ -370,8 +372,8 @@ def get_failures(target_path, thread_mode, backend_pattern):
         'timeout',
         '0.0000']
     for suite_name in suite_list:
-        perf_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(target_path, backend_pattern, suite_name, args.precision, args.infer_or_train)
-        acc_path = '{0}/{1}_{2}_{3}_{4}_cpu_accuracy.csv'.format(target_path, backend_pattern, suite_name, args.precision, args.infer_or_train)
+        perf_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(target_path, backend_pattern, suite_name, precision, args.infer_or_train)
+        acc_path = '{0}/{1}_{2}_{3}_{4}_cpu_accuracy.csv'.format(target_path, backend_pattern, suite_name, precision, args.infer_or_train)
 
         perf_data = pd.read_csv(perf_path, usecols=["name", "batch_size", "speedup"]).rename(columns={'batch_size': 'perf_bs'})
         acc_data = pd.read_csv(acc_path, usecols=["name", "batch_size", "accuracy"]).rename(columns={'batch_size': 'acc_bs'})
@@ -504,14 +506,15 @@ def update_failures(excel, target_thread, refer_thread, thread_mode):
     sf.to_excel(sheet_name='Failures in '+target_thread.split('_cf')[0].split('inductor_log/')[1].strip(),excel_writer=excel,index=False)
 
 def process_suite(suite, thread):
-    target_file_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(getfolder(args.target, thread), args.backend, suite, args.precision, args.infer_or_train)
+    precision = "amp" if args.precision == "amp_fp16" else args.precision
+    target_file_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(getfolder(args.target, thread), args.backend, suite, precision, args.infer_or_train)
     target_ori_data=pd.read_csv(target_file_path,index_col=0)
     target_data=target_ori_data[['name','batch_size','speedup','abs_latency','compilation_latency']]
     target_data=target_data.copy()
     target_data.sort_values(by=['name'], key=lambda col: col.str.lower(),inplace=True)
 
     if args.reference is not None:
-        reference_file_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(getfolder(args.reference, thread), args.ref_backend, suite, args.precision, args.infer_or_train)
+        reference_file_path = '{0}/{1}_{2}_{3}_{4}_cpu_performance.csv'.format(getfolder(args.reference, thread), args.ref_backend, suite, precision, args.infer_or_train)
         reference_ori_data=pd.read_csv(reference_file_path,index_col=0)
         reference_data=reference_ori_data[['name','batch_size','speedup','abs_latency','compilation_latency']]
         reference_data=reference_data.copy()


### PR DESCRIPTION
The current `inductor_job_result_compare` Jenkins job will use amp instead of amp_fp16 for generating the guilty_commit_search_model_list. This behaviour will mislead the `inductor_local_guilty_commit_job_trigger `Jenkins job to reproduce the amp_bf16 test instead of the intended amp_fp16.