### PR TITLE
fix pt build issue which caused by mpmath 1.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,7 @@ ARG PT_REPO=https://github.com/pytorch/pytorch
 ARG PT_COMMIT=main
 COPY --from=conda /opt/conda /opt/conda
 WORKDIR /workspace
-RUN pip install intel-openmp
+RUN pip install intel-openmp mpmath==1.3.0
 RUN git clone ${PT_REPO} && \
     cd pytorch && git checkout ${PT_COMMIT} && git submodule sync && git submodule update --init --recursive && \
     python setup.py develop && cd ..


### PR DESCRIPTION
When we build PyTorch, it will require mpmath>=1.1.0. The latest mpmath 1.4.0a4 seems to have some installation issues that block the PyTorch build. 
Now we work around this build issue by installing mpmath 1.3.0 before building Pytorch.

```
651.0 Searching for mpmath>=1.1.0
651.0 Reading https://pypi.org/simple/mpmath/
651.1 Downloading https://files.pythonhosted.org/packages/84/11/abae27effb8e072fbb6eddd9deab2501b534659d891dd6e3acfb5dc39b54/mpmath-1.4.0a4.tar.gz#sha256=6e694b18746cbbe2c1ffc25f0737950b679c93a1e23c7da7ac32a283450913bd
651.2 Best match: mpmath 1.4.0a4
651.2 Processing mpmath-1.4.0a4.tar.gz
651.4 error: Couldn't find a setup script in /tmp/easy_install-vpuoahwc/mpmath-1.4.0a4.tar.gz
ERROR: process "/bin/sh -c git clone ${PT_REPO} &&     cd pytorch && git checkout ${PT_COMMIT} && git submodule sync && git submodule update --init --recursive &&     python setup.py develop && cd .." did not complete successfully: exit code: 1

```