### PR TITLE
Fix pt repo name

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,7 @@ ARG PT_COMMIT=main
 COPY --from=conda /opt/conda /opt/conda
 WORKDIR /workspace
 RUN pip install intel-openmp mpmath==1.3.0
-RUN git clone ${PT_REPO} && \
+RUN git clone ${PT_REPO} pytorch && \
     cd pytorch && git checkout ${PT_COMMIT} && git submodule sync && git submodule update --init --recursive && \
     python setup.py develop && cd ..
 ARG TORCH_VISION_COMMIT=default

--- a/groovy/inductor_locally_benchmark.groovy
+++ b/groovy/inductor_locally_benchmark.groovy
@@ -125,7 +125,7 @@ node(us_node){
                     if [ "${TORCH_COMMIT}" == "nightly" ];then
                         # clone pytorch repo
                         cd ${WORKSPACE}
-                        git clone -b ${TORCH_COMMIT} ${TORCH_REPO}
+                        git clone -b ${TORCH_COMMIT} ${TORCH_REPO} pytorch
                         cd pytorch
                         main_commit=`git log -n 1 --pretty=format:"%s" -1 | cut -d '(' -f2 | cut -d ')' -f1`
                         git checkout ${main_commit} 2>&1 | tee -a ${WORKSPACE}/torch_clone.log
@@ -133,7 +133,7 @@ node(us_node){
                     else
                         # clone pytorch repo
                         cd ${WORKSPACE}
-                        git clone ${TORCH_REPO}
+                        git clone ${TORCH_REPO} pytorch
                         cd pytorch
                         git checkout ${TORCH_COMMIT} 2>&1 | tee -a ${WORKSPACE}/torch_clone.log
                         result=${PIPESTATUS[0]}


### PR DESCRIPTION
The development team has a new requirement to use a PyTorch repo with a different repo name. such as https://github.com/timocafe/tewart-pytorch.git. The name of this repo is `tewart-pytorch` instead of pytorch.
While we are hardcoding the `cd pytorch` command after cloning the PyTorch repo.
Fixed this issue in this PR.