### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN curl -fsSL -v -k -o ~/miniforge.sh -O https://github.com/conda-forge/minifor
         astunparse \
         cffi \
         cython \
-        cmake=3.26 \
+        cmake=3.27 \
         mamba=1.5.8 \
         dataclasses \
         future \


### PR DESCRIPTION
12:02:30  275.9   File "/workspace/pytorch/setup.py", line 379, in <module>
12:02:30  275.9     cmake = CMake()
12:02:30  275.9   File "/workspace/pytorch/tools/setup_helpers/cmake.py", line 41, in __init__
12:02:30  275.9     self._cmake_command = CMake._get_cmake_command()
12:02:30  275.9   File "/workspace/pytorch/tools/setup_helpers/cmake.py", line 68, in _get_cmake_command
12:02:30  275.9     raise RuntimeError(
12:02:30  275.9 RuntimeError: no cmake or cmake3 with version >= 3.27.0 found:[LooseVersion ('3.26.4'), None]