### PR TITLE
remove deprecated part

### DIFF
--- a/scripts/modelbench/inductor_test.sh
+++ b/scripts/modelbench/inductor_test.sh
@@ -29,21 +29,6 @@ export HUGGING_FACE_HUB_TOKEN=${HF_TOKEN}
 # fix issue: AttributeError: module 'importlib.resources' has no attribute 'files'
 pip uninstall networkx -y && pip install networkx
 
-# Bug fix: only skip cpu test list for torchbench
-# PR: https://github.com/pytorch/pytorch/pull/123544
-result=`sed -n "/    if device ==/p" benchmarks/dynamo/runner.py`
-if [ -z "${result}" ];then
-    echo "patch has been merged"
-else
-    sed -i "/    if device ==/,+4d" benchmarks/dynamo/runner.py
-    sed -i '/        skip_tests.update(module.TorchBenchmarkRunner().skip_models)/i\
-        if device == "cpu":\
-            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cpu)\
-        elif device == "cuda":\
-            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cuda)
-    ' benchmarks/dynamo/runner.py
-fi
-
 # skip sam & nanogpt_generate for stable results
 # skip llama_v2_7b_16h due to OOM
 sed -i '/skip_str = " ".join(skip_tests)/a\    skip_str += " -x llama_v2_7b_16h"' benchmarks/dynamo/runner.py


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/123544 merged, remove the local fix, other wise:
```
     if suite == "torchbench":
+        if device == "cpu":
+            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cpu)
+        elif device == "cuda":
+            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cuda)
         skip_tests.update(module.TorchBenchmarkRunner().skip_models)
         if is_training:
             skip_tests.update(
                 module.TorchBenchmarkRunner().skip_not_suitable_for_training_models
             )
-        if device == "cpu":
-            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cpu)
-            if arch == "aarch64":
-                skip_tests.update(
-                    module.TorchBenchmarkRunner().skip_models_for_cpu_aarch64
                 )
```
```
  File "/workspace/pytorch/benchmarks/dynamo/runner.py", line 390
    )
IndentationError: unexpected indent
```